### PR TITLE
Add documentation for OpenAI Proxy feature

### DIFF
--- a/Usage/API Connections/openai.md
+++ b/Usage/API Connections/openai.md
@@ -26,3 +26,41 @@ If you have access to Anthropic's Claude API:
 - select 'Claude' for 'Chat Completion Source'
 - Input your API key
 - Click connect.
+
+## Proxy
+
+!!!
+If your intent is to use this proxy feature to use a local endpoint, like TabbyAPI, Oobabooga, Aphrodite, or any like those, you might want to check out the[built-in endpoints for those](https://docs.sillytavern.app/usage/api-connections/) instead.  
+This proxy feature is mainly intended for use with other cloud services that expose an OpenAI compatible API chat completion endpoint, such as Microsoft Azure.
+
+Most local APIs support far greater customization options than OpenAI's standards allow for.
+These greater customization options may be worthwhile for SillyTavern users to check out, such as the Min-P sampler, which can greatly improve the quality of generations.
+!!!
+
+It is possible to configure a proxy/alternative endpoint for OpenAI's backend.
+This custom endpoint can be used to connect to alternative chat completion APIs that support the generic OpenAI chat completion API.
+Examples of backends which implement this API are:
+
+This feature is accessed by:
+
+- Selecting 'OpenAI' for 'Chat Completion Source'
+- Leaving the details like API key empty
+- Opening the 'AI Response Configuration' tab and scrolling down to the 'OpenAI / Claude Reverse Proxy' section
+
+In there, you may enter the proxy/custom endpoint and optionally an API key under 'Proxy Password'.
+TabbyAPI provides you with an API key you have to use.
+
+Back in the 'AI Connections' tab, you can find two optional checkboxes labeled:
+
+- Bypass API status check 
+- Show "External" models (provided by API)
+
+Checking 'Bypass API status check' tells SillyTavern to stop alerting you about a non-functioning API endpoint.
+Check this if your API endpoint works, but SillyTavern keeps warning you anyway.
+
+Checking 'Show "External" models (provided by API)' will show the external available models provided by your custom API endpoint in the dropdown.
+This allows you to select different API models right from SillyTavern without having to go into your custom app and change the model.
+**This feature not required for custom API endpoints to work** and might not be available on every backend.
+
+
+

--- a/Usage/API Connections/openai.md
+++ b/Usage/API Connections/openai.md
@@ -23,8 +23,8 @@ WindowAI & OpenRouter allows connection to these as well.
 
 If you have access to Anthropic's Claude API:
 
-- select 'Claude' for 'Chat Completion Source'
-- Input your API key
+- Select 'Claude' for 'Chat Completion Source'.
+- Input your API key.
 - Click connect.
 
 ## Proxy
@@ -43,17 +43,17 @@ Examples of backends which implement this API are:
 
 This feature is accessed by:
 
-- Selecting 'OpenAI' for 'Chat Completion Source'
-- Leaving the details like API key empty
-- Opening the 'AI Response Configuration' tab and scrolling down to the 'OpenAI / Claude Reverse Proxy' section
+- Selecting 'OpenAI' for 'Chat Completion Source'.
+- Leaving the details like API key empty.
+- Opening the 'AI Response Configuration' tab and scrolling down to the 'OpenAI / Claude Reverse Proxy' section.
 
 In there, you may enter the proxy/custom endpoint and optionally an API key under 'Proxy Password'.
 TabbyAPI provides you with an API key you have to use.
 
 Back in the 'AI Connections' tab, you can find two optional checkboxes labeled:
 
-- Bypass API status check 
-- Show "External" models (provided by API)
+- Bypass API status check.
+- Show "External" models (provided by API).
 
 Checking 'Bypass API status check' tells SillyTavern to stop alerting you about a non-functioning API endpoint.
 Check this if your API endpoint works, but SillyTavern keeps warning you anyway.


### PR DESCRIPTION
As promised @Cohee1207, my end of the bargain. I wrote documentation for the OpenAI proxy/custom endpoint part. I deliberately added the words "custom endpoint" as well, as that might be what people are looking for instead.

I also added an alert, which I hope I did right, to inform users about the lacking features in the OpenAI standard, informing them that this feature is mainly intended for use with other yet unsupported cloud services. The first one to come up in my was Microsoft Azure, so that's the one I wrote down. Honestly the thought of someone RP'ing their waifu using Azure is hilarious to me somehow, so I want to keep that in :rofl: 