### PR TITLE
Update example manifest.json

### DIFF
--- a/For Contributors/Writing-Extensions.md
+++ b/For Contributors/Writing-Extensions.md
@@ -28,21 +28,28 @@ Every extension must have a folder in `public/scripts/extensions` and have a man
 ```js
 {
     "display_name": "The name of the plugin",
-    "loading_order": 1, // Optional. Higher number loads later
-    "requires": [], // Required Extras modules dependencies.
-    "optional": [], // Optional Extras dependencies
-    "js": "index.js", // Main JS file
-    "css": "style.css", // (Optional) CSS file
+    "loading_order": 1,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
     "author": "Your name",
     "version": "1.0.0",
     "homePage": "https://github.com/your/plugin",
-    "auto_update": true // If the extension should auto-update when the version of the ST package changes
+    "auto_update": true
 }
 ```
 
-The `display_name`, `js`, and `author` fields are required.
+`display_name` is required
+`loading_order` is optional. Higher number loads later
+`requires` specifies the required Extras modules dependencies.
+`optional` specifies the optional Extras dependencies
+`js` is the main JS file, and is required
+`css` is Optional
+`author` is required
+`auto_update` is set top true if the extension should auto-update when the version of the ST package changes
 
-Downloadable extensions are installed into the `public/scripts/extensions/third-party` folder.
+Downloadable extensions are installed into the `public/scripts/extensions/third-party` folder. Be careful about where you create your extension during development, if you plan on installing it from your github which overrites content in the `third-party` folder.
 
 #### `requires` vs `optional`
 


### PR DESCRIPTION
Removed inline comments from the manifest.json example provided in the documentation.
Updated the documentation to separately explain each field of the manifest.json file, ensuring clarity for users who may copy the example directly.

**Reason for Changes:**
The original manifest.json example included inline comments to describe each field's purpose and requirements. However, JSON does not support comments, and users copying the example directly into their projects might encounter parsing errors if they do not realize that these comments need to be removed. This update aims to prevent such confusion by providing explanations outside of the example JSON structure, ensuring that both novice and experienced developers can successfully utilize the example with minimal modifications and less mistakes.

This update ensures our documentation is both accurate and user-friendly, reducing the risk of errors for developers integrating their extensions.