### PR TITLE
Change higher for larger in worldinfo.md

### DIFF
--- a/Usage/worldinfo.md
+++ b/Usage/worldinfo.md
@@ -324,7 +324,7 @@ You can define a threshold relative to your API's max-context settings (Context 
 
 If the budget is exhausted, then no more entries are activated even if the keys are present in the prompt.
 
-Constant entries will be inserted first. Then entries with higher order numbers.
+Constant entries will be inserted first. Then entries with larger order numbers.
 
 Entries inserted by directly mentioning their keys have higher priority than those that were mentioned in other entries' contents.
 


### PR DESCRIPTION
I was confused by this so wanted to suggest this change. "Higher" doesn't mean "A larger number" in every context (eg "high priority" often means Priority 1 and "low priority" means Priority 5) so I think using the word "larger" is clearer, and an example shows how it will be used.