### PR TITLE
Macros 2.0 Document new variable shorthands & delvar/hasvar macros

### DIFF
--- a/Usage/macros.md
+++ b/Usage/macros.md
@@ -416,15 +416,15 @@ The following operators can be used with variable shorthands. Each operator foll
 | Operator | Name                      | Example                | Description                                            |
 | -------- | ------------------------- | ---------------------- | ------------------------------------------------------ |
 | *(none)* | [Get](#get-variable)      | `{{.myvar}}`           | Returns the variable value                             |
-| `=`      | [Set](#set-variable)      | `{{.myvar = value}}`   | Sets the variable to a value                           |
+| `=`      | [Set](#set-variable)      | `{{.myvar = value}}`   | Sets the variable to a value, returns nothing         |
 | `++`     | [Increment](#increment)   | `{{.counter++}}`       | Increments by 1, returns new value                     |
 | `--`     | [Decrement](#decrement)   | `{{.counter--}}`       | Decrements by 1, returns new value                     |
-| `+=`     | [Add](#add)               | `{{.score += 10}}`     | Adds to variable (numeric or string concatenation)     |
-| `-=`     | [Subtract](#subtract)     | `{{.health -= 5}}`     | Subtracts from variable (numeric only)                 |
+| `+=`     | [Add](#add)               | `{{.score += 10}}`     | Adds to variable (numeric or string concatenation), returns nothing |
+| `-=`     | [Subtract](#subtract)     | `{{.health -= 5}}`     | Subtracts from variable (numeric only), returns nothing |
 | `\|\|`   | [Logical Or](#logical-or) | `{{.name \|\| Guest}}` | Returns fallback if variable is falsy                  |
 | `??`     | [Nullish Coalescing](#nullish-coalescing) | `{{.name ?? Guest}}` | Returns fallback only if variable is undefined |
-| `\|\|=`  | [Logical Or Assign](#logical-or-assign) | `{{.name \|\|= Guest}}` | Sets value if variable is falsy              |
-| `??=`    | [Nullish Coalescing Assign](#nullish-coalescing-assign) | `{{.name ??= Guest}}` | Sets value only if variable is undefined |
+| `\|\|=`  | [Logical Or Assign](#logical-or-assign) | `{{.name \|\|= Guest}}` | Sets value if variable is falsy, returns the new value |
+| `??=`    | [Nullish Coalescing Assign](#nullish-coalescing-assign) | `{{.name ??= Guest}}` | Sets value only if variable is undefined, returns the new value |
 | `==`     | [Equals](#equals)         | `{{.status == active}}`| Compares values, returns `"true"` or `"false"`         |
 | `!=`     | [Not Equals](#not-equals) | `{{.status != active}}`| Compares values, returns `"true"` if not equal         |
 


### PR DESCRIPTION
Docs for https://github.com/SillyTavern/SillyTavern/pull/4997

## Copilot Summary
This pull request significantly expands and clarifies the documentation for variable shorthands and operators in the `Usage/macros.md` file. The updates provide detailed explanations, examples, and usage patterns for all supported shorthand operations, making the section much more comprehensive and user-friendly. Additionally, the legacy syntax table is updated to include missing macros for variable existence checks and deletion.

Key documentation improvements:

* Added a comprehensive section detailing variable names, nested macros in values, whitespace handling, and all supported variable shorthand operators, including `=`, `++`, `--`, `+=`, `-=`, `||`, `??`, `||=`, `??=`, `==`, and `!=`, each with explanations and examples. [[1]](diffhunk://#diff-2fe74f563e48c1cc4e4407e61f530ee69f9a09793dad82eecbc778a2cd512a5dL381-R431) [[2]](diffhunk://#diff-2fe74f563e48c1cc4e4407e61f530ee69f9a09793dad82eecbc778a2cd512a5dL392-R442) [[3]](diffhunk://#diff-2fe74f563e48c1cc4e4407e61f530ee69f9a09793dad82eecbc778a2cd512a5dL403-R475) [[4]](diffhunk://#diff-2fe74f563e48c1cc4e4407e61f530ee69f9a09793dad82eecbc778a2cd512a5dL425-R583)
* Clarified the rules for valid variable names and how to handle non-standard identifiers.
* Improved section titles and organization for better readability (e.g., "Variable Shorthands Prefix Operators" to "Variable Shorthands Prefixes").

Legacy macro table updates:

* Added `hasvar`, `deletevar`, `hasglobalvar`, and `deleteglobalvar` to the legacy macro table for completeness.