### PR TITLE
Fix macro documentation links in multiple files

### DIFF
--- a/Usage/Prompts/context-template.md
+++ b/Usage/Prompts/context-template.md
@@ -18,7 +18,7 @@ Edit these settings in the "[Advanced Formatting](advancedformatting.md)" panel.
 
 This field is a template for the prompt preamble (known internally as a story string). This is the main way to add the information defined in [Character Cards](/Usage/Characters/index.md) for text completion and instruct models.
 
-The template supports Handlebars syntax, custom text injections or formatting, and any other [macros](/Usage/Characters/macros.md). See the language reference here: <https://handlebarsjs.com/guide/>
+The template supports Handlebars syntax, custom text injections or formatting, and any other [macros](/usage/macros.md). See the language reference here: <https://handlebarsjs.com/guide/>
 
 We provide the following parameters to the Handlebars evaluator (wrapped in double curly braces):
 

--- a/Usage/Prompts/index.md
+++ b/Usage/Prompts/index.md
@@ -69,7 +69,7 @@ The default Main Prompt is:
 
 The \{\{char\}\} and \{\{user\}\} placeholders are replaced with the names of the character and persona that you've defined in the conversation. 
 
-You can use any of the supported [\{\{macro\}\}](/Usage/Characters/macros.md) tags in the Main Prompt to include information that might vary between conversations or changes as the conversation progresses.
+You can use any of the supported [\{\{macro\}\}](/usage/macros.md) tags in the Main Prompt to include information that might vary between conversations or changes as the conversation progresses.
 
 ### Adjusting the Main Prompt
 

--- a/Usage/personas.md
+++ b/Usage/personas.md
@@ -33,7 +33,7 @@ Since `{{user}}` and `{{char}}` macros have opposite meanings when used in Perso
 
 ## Persona Description
 
-Each persona can store a custom text description — mental and physical traits, age, occupation, or any personal details. These can also include template macros such as `{{char}}` or `{{user}}` (see [Macros](/Usage/Characters/macros.md)).
+Each persona can store a custom text description — mental and physical traits, age, occupation, or any personal details. These can also include template macros such as `{{char}}` or `{{user}}` (see [Macros](/usage/macros.md)).
 
 Where your persona description is injected into the AI prompt depends on the **Position** setting in the Persona Management panel:
 

--- a/extensions/Regex.md
+++ b/extensions/Regex.md
@@ -56,7 +56,7 @@ Below this is a list of your scripts with some action buttons.
 
 - **Name** : The label for the script shown on the extension's script list. **This is also used to target the script when triggering it via slash command or STscript.**
 
-- **Find Regex** : This is the Regular Expression that is used to detect your targeted text pattern. This is usually the most complex part of any RegEx script, and is the easiest place to make mistakes. Refer to the links at the top of the page for information how to write a RegEx sequence. This box can resolve the values of [common SillyTavern macros](/Usage/Characters/macros.md) (such as \{\{user\}\}, \{\{char\}\}, etc) if the 'Macros in Find Regex' is set to do so (see below).
+- **Find Regex** : This is the Regular Expression that is used to detect your targeted text pattern. This is usually the most complex part of any RegEx script, and is the easiest place to make mistakes. Refer to the links at the top of the page for information how to write a RegEx sequence. This box can resolve the values of [common SillyTavern macros](/usage/macros.md) (such as \{\{user\}\}, \{\{char\}\}, etc) if the 'Macros in Find Regex' is set to do so (see below).
 
 - **Replace With**: This is what will replace the matched sequence. In a very simple example, if your 'Find Regex' is `apple`, and your 'Replace With' is `orange`, the first occurrence of 'apple' would be automatically changed to 'orange' in any text where the script is applied.
 


### PR DESCRIPTION
After moving the docs, we didn't realize we should fix links too.

This pull request updates documentation links to the macros reference throughout the project, ensuring consistency and preventing broken links. All references to the macros documentation are now correctly pointed to `/usage/macros.md` instead of the previous, outdated paths.

**Documentation link updates:**

* Updated references to the macros documentation in `Usage/Prompts/context-template.md`, `Usage/Prompts/index.md`, `Usage/personas.md`, and `extensions/Regex.md` to use `/usage/macros.md` for consistency and to avoid broken links. [[1]](diffhunk://#diff-faa9c4b9dee6f4e2a2365e8a8950f07238e3a408656b7b4d2b6424ff7f6086dcL21-R21) [[2]](diffhunk://#diff-c1b537a46cd24e60c413397635adc81b3333085a6695becf17478c8e7357c9eaL72-R72) [[3]](diffhunk://#diff-e8671e72398b0027ea67cafca57727cbd9bffe0ec7e29369f05453085a44810cL36-R36) [[4]](diffhunk://#diff-1787d28fb59b3aa837846840fc01643043613b442b93e6733818ebcf0a8e1e76L59-R59)