### PR TITLE
Change pollinations.ai from Free to Paid. reflecting the changes to a pay per call model in the newest TOS

### DIFF
--- a/extensions/Stable-Diffusion.md
+++ b/extensions/Stable-Diffusion.md
@@ -45,7 +45,7 @@ Most common Stable Diffusion generation settings are customizable within the Sil
 | [NovelAI Diffusion](https://novelai.net/)                                                         | Cloud, requires an active subscription                                                          |
 | [OpenAI](https://platform.openai.com/)                                                            | Cloud, paid                                                                                     |
 | [OpenRouter](https://openrouter.ai/)                                                              | Cloud                                                                                           |
-| [Pollinations](https://pollinations.ai/)                                                          | Cloud, open source (MIT), free of charge                                                        |
+| [Pollinations](https://pollinations.ai/)                                                          | Cloud, open source (MIT), Paid                                                        |
 | [SD.Next / vladmandic](https://github.com/vladmandic/automatic)                                   | Local, open source (AGPL3), free of charge                                                      |
 | [SillyTavern Extras](https://github.com/SillyTavern/SillyTavern-Extras)                           | Deprecated, not recommended                                                                     |
 | [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp)                            | Local, open source (MIT), free of charge                                                        |


### PR DESCRIPTION
https://enter.pollinations.ai/
under the "can i try it for free"
"complete Quests from the Quests dashboard to earn Pollen."

under "what is pollen?"
Pollen is our prepaid credit system. $1 ≈ 1 Pollen (pricing may evolve).

🔒 Pollen is in-app credit for the Pollinations API. It lives inside your Pollinations wallet, isn't transferable between accounts, and isn't redeemable outside Pollinations.

⚡ You spend Pollen to make API calls — every generation costs Pollen based on the model you use.


an example image of the quests page. on a new account. created today, 10/07/2026. users can earn pollen through PR's buying pollen, and using pollen. https://imgur.com/a/Jlzzlo5 pollen expires after 12 months

note the new "description" for pollinations.ai applied to social media accounts  "pollinations.ai is an open-source credit-based AI platform for developers who want to build fast, experiment freely, and ship real products. We provide a unified multimodal API for images, text, and audio, with real-time and video generation coming next. At the core is Pollen, a simple credit system that keeps usage clear and predictable. Around it, a growing community of developers is already building tools, games, and creative experiments together."  https://www.reddit.com/r/pollinations_ai/

<img width="850" height="1895" alt="firefox_y5nxvwo4vB" src="https://github.com/user-attachments/assets/028b6daa-0812-4700-9cf1-958cc4bff3de" />
